### PR TITLE
added etherpad to commcall template

### DIFF
--- a/models.js
+++ b/models.js
@@ -27,6 +27,7 @@ var eventSchema = new Schema({
   end: Date,
   where: String,
   template: String,
+  notes: String,
   facilitators: [{ type: Schema.Types.ObjectId, ref: 'User' }],
   attending: [{ type: Schema.Types.ObjectId, ref: 'User' }],
   slug: String

--- a/routes/events.js
+++ b/routes/events.js
@@ -63,6 +63,9 @@ module.exports = function() {
           res.status(404).end();
         } else {
           if (err) return console.error(err);
+          console.log('==================')
+          console.log(JSON.stringify(ev, null, 4))
+          console.log('==================')
           if(req.xhr) res.json(ev);
           var template = ev.template ? 'events/' + ev.template : 'event.jade';
           res.render(template, { ev:ev });

--- a/routes/events.js
+++ b/routes/events.js
@@ -63,9 +63,6 @@ module.exports = function() {
           res.status(404).end();
         } else {
           if (err) return console.error(err);
-          console.log('==================')
-          console.log(JSON.stringify(ev, null, 4))
-          console.log('==================')
           if(req.xhr) res.json(ev);
           var template = ev.template ? 'events/' + ev.template : 'event.jade';
           res.render(template, { ev:ev });

--- a/views/events/communitycall.jade
+++ b/views/events/communitycall.jade
@@ -53,6 +53,12 @@ html
               li Room code (conference number): 7677
               li Note:  you can call the 1-800 number free of charge using Skype or other VoIP clients
 
+          if(ev.notes)
+            h2 Notes
+            p The notes can be found in 
+              a(href=ev.notes)  Etherpad
+          else 
+            h2 No Notes :( 
 
           if(ev.facilitators.length > 0)
             h3 FACILITATORS

--- a/views/events/communitycall.jade
+++ b/views/events/communitycall.jade
@@ -55,7 +55,7 @@ html
 
           if(ev.notes)
             h2 Notes
-            p The notes can be found in 
+            p The notes can be found in the
               a(href=ev.notes)  Etherpad
           else 
             h2 No Notes :( 


### PR DESCRIPTION
@acabunoc, per our convo yesterday, I tried to add a field for "notes" in both mongo and then the .jade template for community calls.

For some reason it's always defalting to the "else" statement when I run it locally, i.e. "No Notes".
```
if(ev.notes)
    h2 Notes
    p The notes can be found in 
    a(href=ev.notes)  Etherpad
else 
    h2 No Notes :( 
```
I added a notes field in the MongoDB page for Jan 14 too, and when I logged it out (there's some console log statements in the `events.js` file), it's returning the right data, so I'm not sure what's up. :(

![screen shot 2015-12-23 at 10 01 58 am](https://cloud.githubusercontent.com/assets/1559703/11979026/051ae0de-a95e-11e5-8395-b0b986053d09.png)


Any tips?